### PR TITLE
Insert intermediate certificate on SSVM keystore

### DIFF
--- a/systemvm/scripts/config_ssl.sh
+++ b/systemvm/scripts/config_ssl.sh
@@ -178,6 +178,7 @@ if [ -f "$customCACert" ]
 then
   keytool -delete -alias $aliasName -keystore $keyStore -storepass $storepass -noprompt
   keytool -import -alias $aliasName -keystore $keyStore -storepass $storepass -noprompt -file $customCACert
+  keytool -import -alias ${aliasName}CHAIN -keystore $keyStore -storepass $storepass -noprompt -file $customCertChain
 fi
 
 if [ -d /etc/apache2 ]


### PR DESCRIPTION
Insert intermediate AC_SSL certificate on SSVM Keystore to fiz trusting problems with custom selfsigning CA.